### PR TITLE
Improve tagging process

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - v*
 
 jobs:
   build:
@@ -11,6 +13,16 @@ jobs:
   
     steps:
     - uses: actions/checkout@v2
+
+    - name: Extract DOCKER_TAG using tag name
+      if: startsWith(github.ref, 'refs/tags/')
+      run: |
+        echo "DOCKER_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+    
+    - name: Use default DOCKER_TAG
+      if: startsWith(github.ref, 'refs/tags/') != true
+      run: |
+        echo "DOCKER_TAG=latest" >> $GITHUB_ENV
     
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -27,7 +39,7 @@ jobs:
     - uses: docker/build-push-action@v2
       with:
         push: true
-        tags: ${{ github.repository }}:latest
+        tags: ${{ github.repository }}:${{ env.DOCKER_TAG }}
     
     - name: Send Compile action
       run: |


### PR DESCRIPTION
This PR will automatically create a specific docker tag, if a git tag is created in the repo if the tag starts by v.
So for instance, if we create a tag in the repo as v1.2 this will create a new docker layer image named ps2dev/ps2toolchain-iop:v1.2

If not, as usual, every single change will create a tag named ps2dev/ps2toolchain-iop:latest

Thanks