### PR TITLE
Add mipsel-ps2-elf target

### DIFF
--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -39,7 +39,7 @@ fi
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## For each target...
-for TARGET in "mipsel-ps2-irx"; do
+for TARGET in "mipsel-ps2-irx" "mipsel-ps2-elf"; do
   ## Create and enter the toolchain/build directory
   rm -rf "build-$TARGET"
   mkdir "build-$TARGET"

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -60,5 +60,8 @@ for TARGET in "mipsel-ps2-irx" "mipsel-ps2-elf"; do
   make --quiet -j "$PROC_NR" install-strip
   make --quiet -j "$PROC_NR" clean
 
+  ## Exit the build directory.
+  cd ..
+
   ## End target.
 done

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -39,7 +39,7 @@ fi
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## For each target...
-for TARGET in "mipsel-ps2-irx"; do
+for TARGET in "mipsel-ps2-irx" "mipsel-ps2-elf"; do
   ## Create and enter the toolchain/build directory
   rm -rf "build-$TARGET-stage1"
   mkdir "build-$TARGET-stage1"


### PR DESCRIPTION
Future support for https://github.com/ps2dev/ps2sdk/pull/253

(`mipsel-ps2-irx` will be removed in a separate PR once the above and the next binutils update is ready)  