### PR TITLE
Disable TLS

### DIFF
--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -71,6 +71,7 @@ for TARGET in "mipsel-ps2-irx" "mipsel-ps2-elf"; do
     --disable-target-libiberty \
     --disable-target-zlib \
     --disable-nls \
+    --disable-tls \
     $TARG_XTRA_OPTS
 
   ## Compile and install.


### PR DESCRIPTION
The IOP kernel doesn't support TLS, disable it to prevent GCC from emitting RDHWR instructions.