### PR TITLE
Use mainstream GCC 12.1.0 and Binutils 2.39.0

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -44,6 +44,7 @@ jobs:
       run: |
         export PS2DEV=$PWD/ps2dev
         export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+        export PATH="/usr/local/opt/bison/bin:$PATH"
         export PATH=$PATH:$PS2DEV/iop/bin
         ./toolchain.sh
 
@@ -51,6 +52,6 @@ jobs:
       run: |
         export PS2DEV=$PWD/ps2dev
         export PATH=$PATH:$PS2DEV/iop/bin
-        mipsel-ps2-irx-as --version
-        mipsel-ps2-irx-ld --version
-        mipsel-ps2-irx-gcc --version
+        mipsel-ps2-elf-as --version
+        mipsel-ps2-elf-ld --version
+        mipsel-ps2-elf-gcc --version

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -9,9 +9,9 @@ onerr()
 trap onerr ERR
 
 ## Download the source code.
-REPO_URL="https://github.com/ps2dev/binutils-gdb.git"
+REPO_URL="https://github.com/bminor/binutils-gdb.git"
 REPO_FOLDER="binutils-gdb"
-BRANCH_NAME="iop-v2.35.2"
+BRANCH_NAME="binutils-2_39"
 if test ! -d "$REPO_FOLDER"; then
   git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
 else
@@ -39,7 +39,7 @@ fi
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## For each target...
-for TARGET in "mipsel-ps2-irx" "mipsel-ps2-elf"; do
+for TARGET in "mipsel-ps2-elf"; do
   ## Create and enter the toolchain/build directory
   rm -rf "build-$TARGET"
   mkdir "build-$TARGET"

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -11,7 +11,7 @@ trap onerr ERR
 ## Download the source code.
 REPO_URL="https://github.com/ps2dev/gcc.git"
 REPO_FOLDER="gcc"
-BRANCH_NAME="iop-v11.3.0"
+BRANCH_NAME="iop-v12.1.0"
 if test ! -d "$REPO_FOLDER"; then
   git clone --depth 1 -b "$BRANCH_NAME" "$REPO_URL"
 else
@@ -39,7 +39,7 @@ fi
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
 ## For each target...
-for TARGET in "mipsel-ps2-irx" "mipsel-ps2-elf"; do
+for TARGET in "mipsel-ps2-elf"; do
   ## Create and enter the toolchain/build directory
   rm -rf "build-$TARGET-stage1"
   mkdir "build-$TARGET-stage1"


### PR DESCRIPTION
## Description
This PR basically removes the legacy IOP toolchain using now just the mainstream one.

`bison` dependency has been added for compiling in MacOS

## Atention
If you take a look, `gcc` repo is still pointing to `ps2dev`, this is because they have an issue in the `12.1.0` and I have needed to apply 2 different commits by cherry-picking them.
More info here:
https://github.com/ps2dev/gcc/commits/iop-v12.1.0

```
GNU assembler (GNU Binutils) 2.39
Copyright (C) 2022 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or later.
This program has absolutely no warranty.
This assembler was configured for a target of `mipsel-ps2-elf'.
GNU ld (GNU Binutils) 2.39
Copyright (C) 2022 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
mipsel-ps2-elf-gcc (GCC) 12.1.0
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```