### PR TITLE
Use mainstreams

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -59,6 +59,19 @@ jobs:
       run: |
         export PS2DEV=$PWD/ps2dev
         export PATH=$PATH:$PS2DEV/iop/bin
-        mipsel-ps2-irx-as --version
-        mipsel-ps2-irx-ld --version
-        mipsel-ps2-irx-gcc --version
+        mipsel-none-elf-as --version
+        mipsel-none-elf-ld --version
+        mipsel-none-elf-gcc --version
+    
+    - name: Get short SHA
+      id: slug
+      run: printf '%s\n' "sha8=$(printf '%s\n' ${GITHUB_SHA} | cut -c1-8)" >> $GITHUB_OUTPUT
+    
+    - name: Compress ps2dev folder
+      run: |
+        tar -zcvf ps2dev.tar.gz ps2dev
+    
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ps2dev-${{ steps.slug.outputs.sha8 }}-${{ matrix.os[0] }}
+        path: ps2dev.tar.gz

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,12 +29,6 @@ jobs:
       run: |
         echo "DOCKER_TAG=latest" >> $GITHUB_ENV
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: Login to DockerHub
       uses: docker/login-action@v3
       if: env.DOCKER_USERNAME != null

--- a/config/ps2toolchain-iop-config.sh
+++ b/config/ps2toolchain-iop-config.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-PS2TOOLCHAIN_IOP_BINUTILS_REPO_URL="https://github.com/ps2dev/binutils-gdb.git"
-PS2TOOLCHAIN_IOP_BINUTILS_DEFAULT_REPO_REF="iop-v2.35.2"
-PS2TOOLCHAIN_IOP_GCC_REPO_URL="https://github.com/ps2dev/gcc.git"
-PS2TOOLCHAIN_IOP_GCC_DEFAULT_REPO_REF="iop-v14.2.0"
+PS2TOOLCHAIN_IOP_BINUTILS_REPO_URL="https://github.com/bminor/binutils-gdb.git"
+PS2TOOLCHAIN_IOP_BINUTILS_DEFAULT_REPO_REF="binutils-2_43_1"
+PS2TOOLCHAIN_IOP_GCC_REPO_URL="https://github.com/gcc-mirror/gcc.git"
+PS2TOOLCHAIN_IOP_GCC_DEFAULT_REPO_REF="releases/gcc-14.2.0"
 
 if test -f "$PS2DEV_CONFIG_OVERRIDE"; then
   source "$PS2DEV_CONFIG_OVERRIDE"

--- a/scripts/001-binutils.sh
+++ b/scripts/001-binutils.sh
@@ -32,6 +32,7 @@ fi
 
 cd "$REPO_FOLDER"
 
+TARGET="mipsel-none-elf"
 TARGET_ALIAS="iop"
 TARG_XTRA_OPTS=""
 OSVER=$(uname)
@@ -53,31 +54,26 @@ fi
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
-## For each target...
-for TARGET in "mipsel-ps2-irx" "mipsel-none-elf"; do
-  ## Create and enter the toolchain/build directory
-  rm -rf "build-$TARGET"
-  mkdir "build-$TARGET"
-  cd "build-$TARGET"
+## Create and enter the toolchain/build directory
+rm -rf "build-$TARGET"
+mkdir "build-$TARGET"
+cd "build-$TARGET"
 
-  ## Configure the build.
-  ../configure \
-    --quiet \
-    --prefix="$PS2DEV/$TARGET_ALIAS" \
-    --target="$TARGET" \
-    --disable-separate-code \
-    --disable-sim \
-    --disable-nls \
-    --with-python=no \
-    $TARG_XTRA_OPTS
+## Configure the build.
+../configure \
+  --quiet \
+  --prefix="$PS2DEV/$TARGET_ALIAS" \
+  --target="$TARGET" \
+  --disable-separate-code \
+  --disable-sim \
+  --disable-nls \
+  --with-python=no \
+  $TARG_XTRA_OPTS
 
-  ## Compile and install.
-  make --quiet -j "$PROC_NR"
-  make --quiet -j "$PROC_NR" install-strip
-  make --quiet -j "$PROC_NR" clean
+## Compile and install.
+make --quiet -j "$PROC_NR"
+make --quiet -j "$PROC_NR" install-strip
+make --quiet -j "$PROC_NR" clean
 
-  ## Exit the build directory.
-  cd ..
-
-  ## End target.
-done
+## Exit the build directory.
+cd ..

--- a/scripts/002-gcc-stage1.sh
+++ b/scripts/002-gcc-stage1.sh
@@ -32,6 +32,7 @@ fi
 
 cd "$REPO_FOLDER"
 
+TARGET="mipsel-none-elf"
 TARGET_ALIAS="iop"
 TARG_XTRA_OPTS=""
 TARGET_CFLAGS="-O2 -gdwarf-2 -gz"
@@ -54,52 +55,47 @@ fi
 ## Determine the maximum number of processes that Make can work with.
 PROC_NR=$(getconf _NPROCESSORS_ONLN)
 
-## For each target...
-for TARGET in "mipsel-ps2-irx" "mipsel-none-elf"; do
-  ## Create and enter the toolchain/build directory
-  rm -rf "build-$TARGET-stage1"
-  mkdir "build-$TARGET-stage1"
-  cd "build-$TARGET-stage1"
+## Create and enter the toolchain/build directory
+rm -rf "build-$TARGET-stage1"
+mkdir "build-$TARGET-stage1"
+cd "build-$TARGET-stage1"
 
-  ## Configure the build.
-  CFLAGS_FOR_TARGET="$TARGET_CFLAGS" \
-  CXXFLAGS_FOR_TARGET="$TARGET_CFLAGS" \
-  ../configure \
-    --quiet \
-    --prefix="$PS2DEV/$TARGET_ALIAS" \
-    --target="$TARGET" \
-    --enable-languages="c,c++" \
-    --with-float=soft \
-    --with-headers=no \
-    --without-newlib \
-    --without-cloog \
-    --without-ppl \
-    --disable-decimal-float \
-    --disable-libada \
-    --disable-libatomic \
-    --disable-libffi \
-    --disable-libgomp \
-    --disable-libmudflap \
-    --disable-libquadmath \
-    --disable-libssp \
-    --disable-libstdcxx-pch \
-    --disable-multilib \
-    --disable-shared \
-    --disable-threads \
-    --disable-target-libiberty \
-    --disable-target-zlib \
-    --disable-nls \
-    --disable-tls \
-    --disable-libstdcxx \
-    $TARG_XTRA_OPTS
+## Configure the build.
+CFLAGS_FOR_TARGET="$TARGET_CFLAGS" \
+CXXFLAGS_FOR_TARGET="$TARGET_CFLAGS" \
+../configure \
+  --quiet \
+  --prefix="$PS2DEV/$TARGET_ALIAS" \
+  --target="$TARGET" \
+  --enable-languages="c,c++" \
+  --with-float=soft \
+  --with-headers=no \
+  --without-newlib \
+  --without-cloog \
+  --without-ppl \
+  --disable-decimal-float \
+  --disable-libada \
+  --disable-libatomic \
+  --disable-libffi \
+  --disable-libgomp \
+  --disable-libmudflap \
+  --disable-libquadmath \
+  --disable-libssp \
+  --disable-libstdcxx-pch \
+  --disable-multilib \
+  --disable-shared \
+  --disable-threads \
+  --disable-target-libiberty \
+  --disable-target-zlib \
+  --disable-nls \
+  --disable-tls \
+  --disable-libstdcxx \
+  $TARG_XTRA_OPTS
 
-  ## Compile and install.
-  make --quiet -j "$PROC_NR" all
-  make --quiet -j "$PROC_NR" install-strip
-  make --quiet -j "$PROC_NR" clean
+## Compile and install.
+make --quiet -j "$PROC_NR" all
+make --quiet -j "$PROC_NR" install-strip
+make --quiet -j "$PROC_NR" clean
 
-  ## Exit the build directory.
-  cd ..
-
-  ## End target.
-done
+## Exit the build directory.
+cd ..


### PR DESCRIPTION
Now that we have created a tool for transforming from ELF to IRX in `ps2sdk` we don't require anymore to use custom patches for `binutils` and/or `gcc`.

Cheers!