### PR TITLE
Upgrade binutils 2.44

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -44,8 +44,9 @@ jobs:
       with:
         msystem: MINGW32
         install: |
-          base-devel git make texinfo flex bison patch binutils mingw-w64-i686-gcc mpc-devel tar
-          mingw-w64-i686-cmake mingw-w64-i686-make mingw-w64-i686-libogg
+          base-devel git make texinfo flex bison patch binutils mpc-devel tar
+          mingw-w64-i686-readline mingw-w64-i686-gcc mingw-w64-i686-cmake 
+          mingw-w64-i686-make mingw-w64-i686-libogg
         update: true
 
     - name: Runs all the stages in the shell

--- a/config/ps2toolchain-iop-config.sh
+++ b/config/ps2toolchain-iop-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-PS2TOOLCHAIN_IOP_BINUTILS_REPO_URL="https://github.com/bminor/binutils-gdb.git"
-PS2TOOLCHAIN_IOP_BINUTILS_DEFAULT_REPO_REF="binutils-2_43_1"
+PS2TOOLCHAIN_IOP_BINUTILS_REPO_URL="https://github.com/ps2dev/binutils-gdb.git"
+PS2TOOLCHAIN_IOP_BINUTILS_DEFAULT_REPO_REF="iop-v2.44.0"
 PS2TOOLCHAIN_IOP_GCC_REPO_URL="https://github.com/gcc-mirror/gcc.git"
 PS2TOOLCHAIN_IOP_GCC_DEFAULT_REPO_REF="releases/gcc-14.2.0"
 


### PR DESCRIPTION
Needed to use our fork because we require a patch to compile for clang (MacOS)